### PR TITLE
Use AutoHotkey.com/downloads to install AHK instead of GitHub releases

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,22 @@
+documentation:
+  - changed-files:
+    - any-glob-to-any-file: '**/*.md'
+  - head-branch:
+    - '^doc'
+
+enhancement:
+  - head-branch:
+    - '^feature'
+    - '^feat'
+    - 'feature'
+
+bug:
+  - head-branch:
+    - '^fix'
+    - 'fix'
+    - '^bug'
+
+chore:
+  - head-branch:
+    - '^chore'
+    - '^ci'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,13 @@ jobs:
             version: "2.0.10"
             expected: "2.0.10"
             verify_exact: true
+          - name: latest-21
+            version: "2.1-latest"
+            verify_exact: false
+          - name: specific-21
+            version: "2.1-alpha.20"
+            expected: "2.1-alpha.20"
+            verify_exact: true
     steps:
       - uses: actions/checkout@v6
 
@@ -92,7 +99,7 @@ jobs:
           
           # Write the test script
           @"
-          #Requires AutoHotkey v2.0
+          #Requires AutoHotkey v2
           FileAppend("Hello from AutoHotkey v" A_AhkVersion "!", "$outputFile")
           "@ | Set-Content -Path $scriptFile -Encoding UTF8
           
@@ -147,7 +154,7 @@ jobs:
           
           # Write the test script
           @"
-          #Requires AutoHotkey v2.0
+          #Requires AutoHotkey v2
           FileAppend("Hello from AutoHotkey v" A_AhkVersion "!", "$outputFile")
           "@ | Set-Content -Path $scriptFile -Encoding UTF8
           
@@ -277,7 +284,7 @@ jobs:
           $outputFile = Join-Path $env:RUNNER_TEMP "output_dest.txt"
           
           @"
-          #Requires AutoHotkey v2.0
+          #Requires AutoHotkey v2
           FileAppend("OK", "$outputFile")
           "@ | Set-Content -Path $scriptFile -Encoding UTF8
           
@@ -423,7 +430,7 @@ jobs:
           
           # Test 64-bit
           @"
-          #Requires AutoHotkey v2.0
+          #Requires AutoHotkey v2
           FileAppend(A_PtrSize = 8 ? "64-bit" : "32-bit", "$output64File")
           "@ | Set-Content -Path $script64 -Encoding UTF8
           
@@ -443,7 +450,7 @@ jobs:
           
           # Test 32-bit
           @"
-          #Requires AutoHotkey v2.0
+          #Requires AutoHotkey v2
           FileAppend(A_PtrSize = 8 ? "64-bit" : "32-bit", "$output32File")
           "@ | Set-Content -Path $script32 -Encoding UTF8
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Add labels to PRs (used for release note generation)
+  label:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Run Labeler
+        id: label
+        uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
   # Determine if tests should run based on changed files
   changes:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # install-autohotkey
-GitHub Action to install AutoHotkey from the [GitHub releases page](https://github.com/AutoHotkey/AutoHotkey/releases) and add it to the GitHub runner `PATH` variable.
+GitHub Action to install AutoHotkey from the [AHK Downloads page](https://www.autohotkey.com/download/) and add it to the GitHub runner `PATH` variable.
 
 ## Usage
 
@@ -17,44 +17,51 @@ The resulting directory structure looks like this. If you need the full path to 
     └── <...>
 ```
 
-#### Default (Install Latest into the Current Working Directory)
+#### Default (Install Latest AHK v2.0 into the Current Working Directory)
 
-Install the latest AutoHotkey release into the current working directory:
+Install the latest stable AutoHotkey v2.0 release into the current working directory:
 ```yml
-- uses: holy-tao/install-autohotkey@v1
+- uses: holy-tao/install-autohotkey@v2
 ```
 
 #### Install a Specific Version
 Specify a version with the `version` parameter. This can be a version string like `v2.0.0`, with or without the leading `v` (thus, `v2.0.0` and `2.0.0` are identical), or the literal string `latest` to install the latest version (this is the default).
 
 ```yml
-- uses: holy-tao/install-autohotkey@v1
+- uses: holy-tao/install-autohotkey@v2
   with:
     version: '2.0.19'
+```
+
+#### Install the Latest Version of a Specific Branch
+Specify `{major}.{minor}-latest` to specifically install the latest version of a minor-version branch. For example, to install the latest v2.1 build:
+
+```yml
+- uses: holy-tao/install-autohotkey@v2
+  with:
+    version: '2.1-latest'
 ```
 
 #### Install into a Specific Directory
 Specify the output directory with the `destination` parameter:
 
 ```yml
-- uses: holy-tao/install-autohotkey@v1
+- uses: holy-tao/install-autohotkey@v2
   with:
-    version: '2.0.19'
+    version: '2.1-alpha.20'
     destination: '${{ runner.temp }}'
 ```
 
 #### Install with the [Compiler](https://github.com/AutoHotkey/Ahk2Exe)
 Specify a version of Ahk2Exe to install, or the literal string `latest` to get the latest version, in the `compiler` parameter:
 ```yml
-- uses: holy-tao/install-autohotkey@v1
+- uses: holy-tao/install-autohotkey@v2
   with:
     version: 'latest'
     compiler: 'latest'
 ```
 By default, the compiler is not installed. Note that running `install-ahk2exe` is not recommended, as it will launch the compiler Gui, which you cannot access in the headless GitHub Action runners.
 
-### Alpha Versions
-Alpha versions (e.g. v2.1 versions) are not supported. Alpha release tags only include source code ([example](https://github.com/AutoHotkey/AutoHotkey/releases/tag/v2.1-alpha.18)), so installing one would require building from source. While possible, this is a much more significant effort than installing from a .zip file.
 
 ## Inputs
 | Name | Type | Description|
@@ -66,7 +73,7 @@ Alpha versions (e.g. v2.1 versions) are not supported. Alpha release tags only i
 ## Outputs
 | Name | Type | Description|
 |------|------|------------|
-| version | String | The version of AutoHotkey that was actually installed. If the version input was not `latest`, this is identical to that value, but never includes a leading "v".
+| version | String | The version of AutoHotkey that was actually installed. If the version input was not `latest` or a version-specific `latest` string, this is identical to that value, but never includes a leading "v".
 | ahk32 | String | The full path to the installed AutoHotkey32.exe executable
 | ahk64 | String | The full path to the installed AutoHotkey64.exe executable
 | ahk2Exe | String | The full path to the installed Ahk2Exe.exe executable, only present if a compiler version was specified

--- a/Scripts/Modules/ahk-utils.psm1
+++ b/Scripts/Modules/ahk-utils.psm1
@@ -1,0 +1,38 @@
+function Get-AhkDownloadInfo() {
+    param(
+        [Parameter(Mandatory = $true)][string] $Version,
+        [hashtable] $Headers = @{ 'User-Agent' = 'PowerShell/install-autohotkey' }
+    )
+
+    $baseUrl = 'https://www.autohotkey.com/download'
+
+    # Normalize bare "latest" to branch-qualified form
+    if ($Version -eq 'latest') {
+        $Version = '2.0-latest'
+    }
+
+    # Handle "{major.minor}-latest" — resolve via version.txt
+    if ($Version -match '^(\d+\.\d+)-latest$') {
+        $branch = $Matches[1]
+        Write-Host "Fetching latest AHK version for branch $branch..."
+        $versionUrl = "$baseUrl/$branch/version.txt"
+        Write-Host "  version.txt URL: $versionUrl"
+        $Version = (Invoke-WebRequest -Uri $versionUrl -UseBasicParsing -Headers $Headers).Content.Trim()
+        Write-Host "  Resolved to: $Version"
+    } else {
+        # Strip optional leading 'v'
+        $Version = $Version.TrimStart('v')
+    }
+
+    # Derive branch (major.minor) from version string
+    if ($Version -notmatch '^(\d+\.\d+)') {
+        throw "Cannot determine download branch from version '$Version'. Expected a format like '2.0.19' or '2.1-alpha.23'."
+    }
+    $branch = $Matches[1]
+
+    return @{
+        Version = $Version
+        Branch  = $branch
+        Url     = "$baseUrl/$branch/AutoHotkey_$Version.zip"
+    }
+}

--- a/Scripts/Modules/ahk-utils.psm1
+++ b/Scripts/Modules/ahk-utils.psm1
@@ -1,7 +1,28 @@
+function Invoke-CurlDownload() {
+    param(
+        [Parameter(Mandatory = $true)][string] $Uri,
+        [string] $OutFile
+    )
+
+    if ($OutFile) {
+        & curl.exe -fsSL -o $OutFile $Uri
+    } else {
+        # Capture stdout (e.g. for version.txt)
+        $output = & curl.exe -fsSL $Uri
+        if ($LASTEXITCODE -ne 0) {
+            throw "curl failed with exit code $LASTEXITCODE fetching: $Uri"
+        }
+        return $output
+    }
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "curl failed with exit code $LASTEXITCODE downloading: $Uri"
+    }
+}
+
 function Get-AhkDownloadInfo() {
     param(
-        [Parameter(Mandatory = $true)][string] $Version,
-        [hashtable] $Headers = @{ 'User-Agent' = 'PowerShell/install-autohotkey' }
+        [Parameter(Mandatory = $true)][string] $Version
     )
 
     $baseUrl = 'https://www.autohotkey.com/download'
@@ -17,7 +38,7 @@ function Get-AhkDownloadInfo() {
         Write-Host "Fetching latest AHK version for branch $branch..."
         $versionUrl = "$baseUrl/$branch/version.txt"
         Write-Host "  version.txt URL: $versionUrl"
-        $Version = (Invoke-WebRequest -Uri $versionUrl -UseBasicParsing -Headers $Headers).Content.Trim()
+        $Version = (Invoke-CurlDownload -Uri $versionUrl).Trim()
         Write-Host "  Resolved to: $Version"
     } else {
         # Strip optional leading 'v'

--- a/Scripts/install-autohotkey.ps1
+++ b/Scripts/install-autohotkey.ps1
@@ -4,26 +4,63 @@ param(
     [string] $Compiler = ""
 )
 
-function Install-Item(){
+function Install-AhkFromDownloadsPage() {
     param(
-        [Parameter(Mandatory = $true)][string] $RepoSlug,
-        [Parameter(Mandatory = $true)][string] $AssetMatch,
         [Parameter(Mandatory = $true)][string] $Version,
         [Parameter(Mandatory = $true)][string] $Destination
     )
 
-    $FriendlyName = $RepoSlug.Split("/") | Select-Object -Last 1
+    Write-Host "Installing AutoHotkey to: $Destination"
+
+    $headers = @{ 'User-Agent' = 'PowerShell/install-autohotkey' }
+
+    $info = Get-AhkDownloadInfo -Version $Version -Headers $headers
+    $resolvedVersion = $info.Version
+    $url = $info.Url
+
+    Write-Host "Resolved AutoHotkey version: $resolvedVersion"
+    Write-Host "Download URL: $url"
+
+    # Connectivity check — helps diagnose auth/TLS issues on runners
+    Write-Host "HEAD check: $url"
+    try {
+        $head = Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing -Headers $headers
+        Write-Host "  Status: $($head.StatusCode) $($head.StatusDescription)"
+    } catch {
+        Write-Warning "  HEAD failed: $($_.Exception.Message)"
+        if ($_.Exception.Response) {
+            Write-Warning "  HTTP status: $([int]$_.Exception.Response.StatusCode)"
+        }
+    }
+
+    $zipPath = Join-Path $PSScriptRoot "AutoHotkey.zip"
+
+    Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing -Headers $headers
+    Expand-Archive -Path $zipPath -DestinationPath $Destination -Force
+    Remove-Item -Path $zipPath -Force
+
+    Write-Host "✅ AutoHotkey $resolvedVersion installed successfully to: $Destination"
+
+    return $resolvedVersion
+}
+
+function Install-CompilerFromGitHub() {
+    param(
+        [Parameter(Mandatory = $true)][string] $Version,
+        [Parameter(Mandatory = $true)][string] $Destination
+    )
+
+    $FriendlyName = "Ahk2Exe"
 
     Write-Host "Installing $FriendlyName to: $Destination"
 
-    $release = Get-GitHubRelease -RepoSlug $RepoSlug -Version $Version -FriendlyName $FriendlyName
-    $version = $release.tag_name.TrimStart('v')
-    Write-Host "Resolved $FriendlyName version: $version"
+    $release = Get-GitHubRelease -RepoSlug "AutoHotkey/Ahk2Exe" -Version $Version -FriendlyName $FriendlyName
+    $resolvedVersion = $release.tag_name.TrimStart('v')
+    Write-Host "Resolved $FriendlyName version: $resolvedVersion"
 
-    $asset = Get-ReleaseAsset -Release $release -Match $AssetMatch
+    $asset = Get-ReleaseAsset -Release $release -Match 'Ahk2Exe.*\.zip$'
 
     $url = $asset.browser_download_url
-
     Write-Host "Download URL: $url"
 
     $zipPath = Join-Path $PSScriptRoot "$FriendlyName.zip"
@@ -32,31 +69,32 @@ function Install-Item(){
     Expand-Archive -Path $zipPath -DestinationPath $Destination -Force
     Remove-Item -Path $zipPath -Force
 
-    Write-Host "✅ $FriendlyName $version installed successfully to: $Destination"
-
-    # Return the resolved version
-    return $version
+    Write-Host "✅ $FriendlyName $resolvedVersion installed successfully to: $Destination"
 }
 
 $ErrorActionPreference = 'Stop'
 
 Import-Module -Name "$PSScriptRoot\Modules\github-utils.psm1" -Force
+Import-Module -Name "$PSScriptRoot\Modules\ahk-utils.psm1" -Force
+
+# Diagnostics — helps identify connectivity/TLS issues on GitHub runners
+Write-Host "=== Diagnostics ==="
+Write-Host "PowerShell: $($PSVersionTable.PSVersion)  OS: $($PSVersionTable.OS)"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Write-Host "TLS forced to: $([Net.ServicePointManager]::SecurityProtocol)"
+Write-Host "==="
 
 if ([string]::IsNullOrWhiteSpace($Destination)) {
     $Destination = (Get-Item .).FullName
 }
 
-# Normalize AHK version to include a leading "v" if it isn't "latest"
-if(-not $Version.Equals("latest") -and -not $Version.StartsWith("v")) {
-    $Version = "v" + $Version
-}
 $extractPath = Join-Path $Destination 'autohotkey'
-$installedVersion = Install-Item -RepoSlug "AutoHotkey/AutoHotkey" -AssetMatch 'AutoHotkey_.*\.zip$' -Version $Version -Destination $extractPath
+$installedVersion = Install-AhkFromDownloadsPage -Version $Version -Destination $extractPath
 
-# Install compiler if asked
+# Install compiler if asked (still sourced from GitHub releases)
 if (-not [string]::IsNullOrWhiteSpace($Compiler)) {
     $compilerExtractPath = Join-Path $extractPath 'Compiler'
-    Install-item -RepoSlug "AutoHotkey/Ahk2Exe" -AssetMatch 'Ahk2Exe.*\.zip$' -Version $Compiler -Destination $compilerExtractPath
+    Install-CompilerFromGitHub -Version $Compiler -Destination $compilerExtractPath
 }
 
 # Export outputs

--- a/Scripts/install-autohotkey.ps1
+++ b/Scripts/install-autohotkey.ps1
@@ -12,30 +12,32 @@ function Install-AhkFromDownloadsPage() {
 
     Write-Host "Installing AutoHotkey to: $Destination"
 
-    $headers = @{ 'User-Agent' = 'PowerShell/install-autohotkey' }
+    $headers = @{ 'User-Agent' = 'PowerShell/install-autohotkey' }  # used for diagnostic HEAD check only
 
-    $info = Get-AhkDownloadInfo -Version $Version -Headers $headers
+    $info = Get-AhkDownloadInfo -Version $Version
     $resolvedVersion = $info.Version
     $url = $info.Url
 
     Write-Host "Resolved AutoHotkey version: $resolvedVersion"
     Write-Host "Download URL: $url"
 
-    # Connectivity check — helps diagnose auth/TLS issues on runners
-    Write-Host "HEAD check: $url"
+    # Diagnostic: show what .NET/PowerShell gets (likely a Cloudflare challenge page on CI runners)
+    Write-Host "HEAD check via Invoke-WebRequest (diagnostic): $url"
     try {
         $head = Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing -Headers $headers
         Write-Host "  Status: $($head.StatusCode) $($head.StatusDescription)"
     } catch {
         Write-Warning "  HEAD failed: $($_.Exception.Message)"
         if ($_.Exception.Response) {
-            Write-Warning "  HTTP status: $([int]$_.Exception.Response.StatusCode)"
+            Write-Warning "  HTTP status: $([int]$_.Exception.Response.StatusCode) (likely Cloudflare bot challenge)"
         }
     }
 
+    # Use curl.exe for the actual download — its TLS fingerprint bypasses Cloudflare's bot detection
+    Write-Host "Downloading via curl.exe: $url"
     $zipPath = Join-Path $PSScriptRoot "AutoHotkey.zip"
 
-    Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing -Headers $headers
+    Invoke-CurlDownload -Uri $url -OutFile $zipPath
     Expand-Archive -Path $zipPath -DestinationPath $Destination -Force
     Remove-Item -Path $zipPath -Force
 


### PR DESCRIPTION
**Previously**, the scripts used AutoHotkey's [GitHub releases](https://github.com/AutoHotkey/AutoHotkey/releases) page to install AHK.

**This was problematic because** Alpha releases aren't available there.

**Now**, we use the [AHK downloads](https://www.autohotkey.com/download/) page to install AHK onto the runner. 2.1 alpha builds *are* available here, so we can now install them and test alpha builds.

This PR also adds the version syntax {version}-latest, e.g. `2.1-latest`, to support installing the latest build of a specific version. `latest` still resolves to the latest 2.0 release, for backwards compatibility and because that's the stable branch right now.

### Changes

- `ahk-utils.psm1`: new module for talking to AutoHotkey.com
- `install-autohotkey.ps1`: use `ahk-utils` to install AutoHotkey

### Testing

Added test cases to `test.yml`. The real test is on the runners, but it works on my local machine.

### Related Issues

<!-- Link to any related issues, e.g., "Closes #123" or "Related to #456" -->

---

#### Checklist

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] No breaking changes (or breaking changes documented)
