### PR TITLE
feat: cache compiled 2.1 AutoHotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The resulting directory structure looks like this. If you need the full path to 
     └── <...>
 ```
 
-v2.1 versions are built from source, so they do not contain the UX directory and some of the other scripts (like the updater) that are included in a default AutoHotkey installation.
+v2.1 versions are built from source, so they do not contain the UX directory and some of the other scripts (like the updater) that are included in a default AutoHotkey installation. Because building from source is slow, the action caches the compiled executables (via [`actions/cache`](https://github.com/actions/cache), keyed on the resolved version) and reuses them on subsequent runs. Set the `force-build` input to `true` to bypass the cache and always rebuild.
 
 #### Default (Install Latest AHK v2.0 into the Current Working Directory)
 
@@ -71,6 +71,7 @@ By default, the compiler is not installed. Note that running `install-ahk2exe` i
 | version | String | The version of AutoHotkey to install, or `latest` to install the latest version according to GitHub Releases. The version can be specified with or without a leading "v" - `v2.0.19` and `2.0.19` behave identically. The version selected must be available from the AutoHotkey [GitHub releases page](https://github.com/AutoHotkey/AutoHotkey/releases), _not_ the tags page.
 | destination | String | The directory in which to create the `autohotkey` directory where AutoHotkey will be installed. By default, this is the current working directory. If this directory does not exist, it will be created.
 | compiler | String | The version of Ahk2Exe, if any, to install. Omit or leave blank to not install Ahk2Exe (default behavior)
+| force-build | Boolean | Only affects v2.1+, which is built from source. By default a successful build is cached (keyed on the resolved version) and reused on later runs. Set to `true` to always rebuild from source and ignore the cache. Has no effect on v2.0, which is downloaded from GitHub Releases. Defaults to `false`.
 
 ## Outputs
 | Name | Type | Description|

--- a/Scripts/Modules/ahk-utils.psm1
+++ b/Scripts/Modules/ahk-utils.psm1
@@ -65,8 +65,29 @@ function Get-LatestAhkAlphaTag() {
 function Build-AhkFromSource() {
     param(
         [Parameter(Mandatory = $true)][string] $Version,
-        [Parameter(Mandatory = $true)][string] $Destination
+        [Parameter(Mandatory = $true)][string] $Destination,
+        [string] $CacheDir = "",
+        [switch] $ForceBuild
     )
+
+    $cacheable = -not [string]::IsNullOrWhiteSpace($CacheDir)
+    $cached32 = if ($cacheable) { Join-Path $CacheDir 'AutoHotkey32.exe' } else { $null }
+    $cached64 = if ($cacheable) { Join-Path $CacheDir 'AutoHotkey64.exe' } else { $null }
+
+    # Use the cached build when present, unless the caller forced a rebuild. The cache is
+    # populated by actions/cache (keyed on the resolved version) before this step runs.
+    if ($cacheable -and -not $ForceBuild -and (Test-Path $cached32) -and (Test-Path $cached64)) {
+        Write-Host "Using cached AutoHotkey $Version build from: $CacheDir"
+        New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+        Copy-Item $cached32 "$Destination\AutoHotkey32.exe" -Force
+        Copy-Item $cached64 "$Destination\AutoHotkey64.exe" -Force
+        Write-Host "✅ AutoHotkey $Version restored from cache to: $Destination"
+        return $Version
+    }
+
+    if ($ForceBuild) {
+        Write-Host "ForceBuild requested — ignoring any cached build."
+    }
 
     Write-Host "Building AutoHotkey $Version from source..."
 
@@ -110,6 +131,15 @@ function Build-AhkFromSource() {
         New-Item -ItemType Directory -Force -Path $Destination | Out-Null
         Copy-Item "$tempDir\bin\AutoHotkey32.exe" "$Destination\AutoHotkey32.exe" -Force
         Copy-Item "$tempDir\bin\AutoHotkey64.exe" "$Destination\AutoHotkey64.exe" -Force
+
+        # Populate the cache dir so actions/cache can persist this build for the next run.
+        # Skipped on ForceBuild, where the cache step is disabled and nothing would be saved.
+        if ($cacheable -and -not $ForceBuild) {
+            New-Item -ItemType Directory -Force -Path $CacheDir | Out-Null
+            Copy-Item "$tempDir\bin\AutoHotkey32.exe" $cached32 -Force
+            Copy-Item "$tempDir\bin\AutoHotkey64.exe" $cached64 -Force
+            Write-Host "Cached AutoHotkey $Version build to: $CacheDir"
+        }
 
     } finally {
         if (Test-Path $tempDir) {

--- a/Scripts/install-autohotkey.ps1
+++ b/Scripts/install-autohotkey.ps1
@@ -1,7 +1,10 @@
 param(
     [string] $Version = "latest",
     [string] $Destination = "",
-    [string] $Compiler = ""
+    [string] $Compiler = "",
+    [string] $CacheDir = "",
+    [switch] $ForceBuild,
+    [switch] $ResolveOnly
 )
 
 function Install-Item(){
@@ -49,11 +52,22 @@ if ([string]::IsNullOrWhiteSpace($Destination)) {
 
 $headers = Get-GitHubApiRequestHeaders
 $resolved = Resolve-AhkVersion -Version $Version -Headers $headers
+$isSourceBuild = ($resolved.Major -eq 2 -and $resolved.Minor -ge 1)
+
+# Resolve-only mode: emit the resolved version (used to key the build cache) and exit.
+# This runs before the cache step so the workflow knows what to restore.
+if ($ResolveOnly) {
+    Write-Output "version=$($resolved.Version)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    Write-Output "is_source_build=$($isSourceBuild.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    Write-Host "Resolved version: '$($resolved.Version)' (source build: $isSourceBuild)"
+    return
+}
+
 $extractPath = Join-Path $Destination 'autohotkey'
 
-if ($resolved.Major -eq 2 -and $resolved.Minor -ge 1) {
+if ($isSourceBuild) {
     # 2.1+ is not published to GitHub releases — build from source
-    $installedVersion = Build-AhkFromSource -Version $resolved.Version -Destination $extractPath
+    $installedVersion = Build-AhkFromSource -Version $resolved.Version -Destination $extractPath -CacheDir $CacheDir -ForceBuild:$ForceBuild
 } else {
     # 2.0 and earlier — download from GitHub releases
     $ghVersion = if ($resolved.Version -eq '') { 'latest' } else { "v$($resolved.Version)" }

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Version of the compiler to install, if any (e.g. "Ahk2Exe1.1.37.02a0a" or "latest")'
     required: false
     default: ''
+  force-build:
+    description: 'Always build 2.1+ from source, ignoring any cached build (no effect for 2.0 releases)'
+    required: false
+    default: 'false'
 
 outputs:
   version:
@@ -33,6 +37,22 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Resolve version
+      id: resolve
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        $scriptPath = Join-Path ${{ github.action_path }} 'scripts/install-autohotkey.ps1'
+        & $scriptPath -Version '${{ inputs.version }}' -ResolveOnly
+
+    - name: Cache AutoHotkey build
+      if: steps.resolve.outputs.is_source_build == 'true' && inputs.force-build != 'true'
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/ahk-cache
+        key: ahk-build-${{ runner.os }}-${{ steps.resolve.outputs.version }}
+
     - name: Run Installer
       id: installer
       shell: pwsh
@@ -40,7 +60,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         $scriptPath = Join-Path ${{ github.action_path }} 'scripts/install-autohotkey.ps1'
-        & $scriptPath -Version '${{ inputs.version }}' -Destination '${{ inputs.destination }}' -Compiler '${{ inputs.compiler }}'
+        & $scriptPath -Version '${{ inputs.version }}' -Destination '${{ inputs.destination }}' -Compiler '${{ inputs.compiler }}' -CacheDir '${{ runner.temp }}/ahk-cache' -ForceBuild:$${{ inputs.force-build }}
 
 branding:
   icon: 'terminal'


### PR DESCRIPTION
Compiling AHK is slow. Cache the output for faster runtimes and add an escape hatch for security-conscious consumers. You're already trusting Lexikos though. Who'd ever use AHK to distribute malware?

**Previously**, the scripts always compiled v2.1 from source whenever it was requested (it's not available as a GitHub release and AutoHotkey.com's bot detection flags GitHub actions runners).

**This was problematic because** compiling code is slow.

**Now**, we cache the compiled output, keyed by version.

---

#### Checklist

- [x] Documentation updated (if needed)
- [x] No breaking changes (or breaking changes documented)
